### PR TITLE
fix: resolve relative MCP_DB_PATH against module dir; raise filterSessionItems depth cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,10 @@ SETUP_KEY=change-me-to-a-strong-random-key
 MCP_JWT_SECRET=
 
 # ── 数据库 ──────────────────────────────────
-# SQLite 数据库文件（自动建库，无需安装 MySQL）
+# SQLite 数据库文件（自动建库，无需安装 MySQL）。
+# 相对路径一律按【模块目录】解析（与 .env 同目录），而非进程 cwd：
+# 网关与 dsh 进程内插件的 cwd 不同，若按 cwd 解析会各自开库（网关能登录、
+# 插件侧 401 的"分库脑裂"）。留空时默认 <模块目录>/data/platform.db。
 MCP_DB_PATH=./data/platform.db
 # 数据静态加密密钥（可选）：openssl rand -hex 32 生成。
 # 留空则从 SETUP_KEY 派生；一旦设置就不能再换，否则旧数据无法解密。

--- a/src/client/card.tsx
+++ b/src/client/card.tsx
@@ -313,6 +313,18 @@ export function DshPasswordsCard(props: PropsLocale<'dshpw'>) {
     );
   };
 
+  /** 退出登录：POST /gateway/logout（服务端吊销会话 + 清 Cookie），随后跳回登录页。
+   *  登出成功/失败都以跳转收尾：失败多半是会话已失效，同样应回到登录页。 */
+  const signOut = () => {
+    setBusy(true);
+    fetch('/gateway/logout', { method: 'POST', credentials: 'same-origin' })
+      .catch(() => undefined)
+      .finally(() => {
+        // 登出后任何后续 API 都会 401/302，直接整页跳转到登录页最干净
+        window.location.assign('/gateway/login');
+      });
+  };
+
   /** 聊天入口按账号跨设备同步；保存成功后立即通知 overlay，无需刷新页面。 */
   const toggleChatEntry = () => {
     const enabled = !chatEnabled;
@@ -489,6 +501,17 @@ export function DshPasswordsCard(props: PropsLocale<'dshpw'>) {
       isAdmin
         ? h('span', { className: 'dshpw-badge admin' }, t('owner'))
         : h('span', { className: 'dshpw-badge' }, t('subuser')),
+      h(
+        'button',
+        {
+          className: 'dshpw-btn danger',
+          style: { marginLeft: 'auto' },
+          disabled: busy || data === null,
+          onClick: signOut,
+          title: t('logoutHint'),
+        },
+        t('logout'),
+      ),
     ),
     // ── 聊天入口：按当前账号跨设备同步的显示偏好 ──
     h(

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -11,6 +11,8 @@ export const zh = {
   identity: '当前身份：',
   owner: '主用户',
   subuser: '子用户',
+  logout: '退出登录',
+  logoutHint: '退出后需重新输入用户名密码登录；会话在服务端立即吊销。',
   // 聊天入口显示偏好（按当前账号跨设备同步）
   chatToggle: '聊天入口',
   chatToggleDesc: '显示可拖动的聊天气泡',
@@ -137,6 +139,8 @@ export const en: Record<keyof typeof zh, string> = {
   identity: 'Signed in as:',
   owner: 'Owner',
   subuser: 'Subuser',
+  logout: 'Sign out',
+  logoutHint: 'You will be asked to sign in again; the session is revoked server-side immediately.',
   chatToggle: 'Chat entry',
   chatToggleDesc: 'Show the draggable chat bubble',
   chatToggleHint: 'The bubble hides immediately when off. Messages are kept and can be restored anytime.',

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,10 @@ export function loadConfig(): PlatformConfig {
     // 会各自开一个新库，表现为“配置改了不生效/数据丢了”）
     path.resolve(moduleDir, '..', 'data', 'platform.db'),
   );
+  // 显式配置的相对路径同样按模块目录解析（而非 cwd）：网关（cwd=插件目录）
+  // 与 dsh 进程内插件（cwd=上游工作目录）必须指向同一数据库文件，否则
+  // 出现"网关能登录、插件侧鉴权 401"的分库脑裂。绝对路径保持原样。
+  const dbPathResolved = path.isAbsolute(dbPath) ? dbPath : path.resolve(moduleDir, dbPath);
 
   // MCP_DSH_RESTART_SERVICE 语义：未设置→默认 'dsh-web'；显式空值→不自动重启。
   // （不能用 readEnv：它会把空值当未设置回退到默认，导致 Windows 上
@@ -114,7 +118,7 @@ export function loadConfig(): PlatformConfig {
   // 留空 = 自动判断：未自备证书且未显式关闭即启用（域名由 cli 启动时补全，
   // 零配置路径会探测公网 IP 推导 <IP>.sslip.io）
   const autoTls = !userCerts && !autoOff && (autoOn || autoTlsRaw === '');
-  const acmeDir = path.join(path.dirname(dbPath), 'acme');
+  const acmeDir = path.join(path.dirname(dbPathResolved), 'acme');
 
   const gatewayPortRaw = readEnv('MCP_GATEWAY_PORT', '8080').trim();
   const gatewayPortNum = Number(gatewayPortRaw);
@@ -126,7 +130,7 @@ export function loadConfig(): PlatformConfig {
 
   return {
     setupKey,
-    dbPath,
+    dbPath: dbPathResolved,
     dbEncKey: readEnv('MCP_DB_ENC_KEY', ''),
     gateway: {
       host: readEnv('MCP_GATEWAY_HOST', '0.0.0.0'),

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -793,7 +793,12 @@ export function filterSessionItems(
   depth = 0,
 ): unknown {
   // 深度超限时丢弃子树；保留原对象会让深层 sessionId/cwd 绕过会话过滤和目录检查。
-  if (depth > 8) return null;
+  // 上限 16 而非 8：真实 session.list 的 typert 信封是
+  //   result → value → items → [i] → projections → values → permissions → options → [o]
+  // 选项对象正好位于深度 9，旧上限 8 会把 permissions.options 元素置 null，
+  // 前端 PermissionSelect 遍历 null 直接崩溃（整条 composer 槽被卸载，子用户
+  // 看不到输入框）。16 仍是有界递归（防上游投毒深嵌套 JSON 栈溢出 DoS）。
+  if (depth > 16) return null;
   if (value === null) return value;
   if (Array.isArray(value)) {
     const out: unknown[] = [];

--- a/test/session-ownership.test.ts
+++ b/test/session-ownership.test.ts
@@ -95,9 +95,49 @@ test('collectSessionCwdFromWorkspaces：活动 sessionIds 映射到工作区路�
 
 test('深度超限：不可验证会话子树不原样透传', () => {
   let value: Record<string, unknown> = { sessionId: 'secret', cwd: '/secret' };
-  for (let i = 0; i < 10; i++) value = { nested: value };
+  for (let i = 0; i < 20; i++) value = { nested: value };
   const out = filterSessionItems(value, () => true) as Record<string, unknown>;
   let cursor: unknown = out;
-  for (let i = 0; i < 10; i++) cursor = (cursor as Record<string, unknown>)?.nested;
+  for (let i = 0; i < 20; i++) cursor = (cursor as Record<string, unknown>)?.nested;
   assert.ok(cursor === null || cursor === undefined);
+});
+
+test('深度上限内：permissions.options 深层投影不被截断', () => {
+  // 回归：真实 session.list 的 permissions.options 选项对象位于深度 9
+  // （result→value→items→[i]→projections→values→permissions→options→[o]），
+  // 旧上限 8 会把它置 null，前端 PermissionSelect 遍历 null 崩溃。
+  const value = {
+    result: {
+      value: {
+        items: [
+          {
+            sessionId: 's-1',
+            cwd: '/allowed',
+            projections: {
+              values: {
+                permissions: {
+                  options: [
+                    { value: 'read-only', name: 'read-only' },
+                    { value: 'workspace-write', name: 'workspace-write' },
+                    { value: 'danger-full-access', name: 'danger-full-access' },
+                  ],
+                  currentValue: 'workspace-write',
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+  const out = filterSessionItems(value, () => true, (cwd) => cwd === '/allowed') as typeof value;
+  const options = out.result.value.items[0].projections.values.permissions.options;
+  assert.deepEqual(
+    options,
+    [
+      { value: 'read-only', name: 'read-only' },
+      { value: 'workspace-write', name: 'workspace-write' },
+      { value: 'danger-full-access', name: 'danger-full-access' },
+    ],
+  );
 });


### PR DESCRIPTION
## 修复内容

两个 bug 修复：

### 1. config: 相对 MCP_DB_PATH 按模块目录解析（commit 5061f9b）

**问题**：`.env` 中 `MCP_DB_PATH=./data/platform.db` 是相对路径，按进程 cwd 解析。网关（cwd=插件目录）与 dsh 进程内插件（cwd=上游工作目录）cwd 不同，各自打开不同的数据库 → 网关能登录、插件侧鉴权 401 → 设置页显示"当前身份：— 子用户"。

**修复**：显式配置的相对路径统一按模块目录解析（`path.resolve(moduleDir, dbPath)`），与默认值语义一致。

### 2. permissions: filterSessionItems 深度上限 8→16（commit 6665ff2）

**问题**：真实 `session.list` 的 typert 信封中 `permissions.options` 元素位于深度 9（result→value→items→[i]→projections→values→permissions→options→[o]），旧上限 8 把受限子用户的 options 置 null → 前端 PermissionSelect 遍历 null 抛 TypeError → 整条 composer 槽被卸载，子用户看不到输入框、无法对话。

**修复**：深度上限 8→16（16 仍是有界递归，防深嵌套 JSON DoS）。

## 验证

- 113/113 测试通过（含新增回归测试）
- 端到端验证：子用户 session.list 的 permissions.options 恢复为完整选项对象
