### PR TITLE
feat(ui): add sign-out button to the password-gate settings card

### DIFF
--- a/src/client/card.tsx
+++ b/src/client/card.tsx
@@ -313,6 +313,18 @@ export function DshPasswordsCard(props: PropsLocale<'dshpw'>) {
     );
   };
 
+  /** 退出登录：POST /gateway/logout（服务端吊销会话 + 清 Cookie），随后跳回登录页。
+   *  登出成功/失败都以跳转收尾：失败多半是会话已失效，同样应回到登录页。 */
+  const signOut = () => {
+    setBusy(true);
+    fetch('/gateway/logout', { method: 'POST', credentials: 'same-origin' })
+      .catch(() => undefined)
+      .finally(() => {
+        // 登出后任何后续 API 都会 401/302，直接整页跳转到登录页最干净
+        window.location.assign('/gateway/login');
+      });
+  };
+
   /** 聊天入口按账号跨设备同步；保存成功后立即通知 overlay，无需刷新页面。 */
   const toggleChatEntry = () => {
     const enabled = !chatEnabled;
@@ -489,6 +501,17 @@ export function DshPasswordsCard(props: PropsLocale<'dshpw'>) {
       isAdmin
         ? h('span', { className: 'dshpw-badge admin' }, t('owner'))
         : h('span', { className: 'dshpw-badge' }, t('subuser')),
+      h(
+        'button',
+        {
+          className: 'dshpw-btn danger',
+          style: { marginLeft: 'auto' },
+          disabled: busy || data === null,
+          onClick: signOut,
+          title: t('logoutHint'),
+        },
+        t('logout'),
+      ),
     ),
     // ── 聊天入口：按当前账号跨设备同步的显示偏好 ──
     h(

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -11,6 +11,8 @@ export const zh = {
   identity: '当前身份：',
   owner: '主用户',
   subuser: '子用户',
+  logout: '退出登录',
+  logoutHint: '退出后需重新输入用户名密码登录；会话在服务端立即吊销。',
   // 聊天入口显示偏好（按当前账号跨设备同步）
   chatToggle: '聊天入口',
   chatToggleDesc: '显示可拖动的聊天气泡',
@@ -137,6 +139,8 @@ export const en: Record<keyof typeof zh, string> = {
   identity: 'Signed in as:',
   owner: 'Owner',
   subuser: 'Subuser',
+  logout: 'Sign out',
+  logoutHint: 'You will be asked to sign in again; the session is revoked server-side immediately.',
   chatToggle: 'Chat entry',
   chatToggleDesc: 'Show the draggable chat bubble',
   chatToggleHint: 'The bubble hides immediately when off. Messages are kept and can be restored anytime.',


### PR DESCRIPTION
Fixes #9

## 问题

用户反馈（Issue #9）：找不到退出登录入口。

## 现状

`/gateway/logout` 接口已存在（POST-only + 服务端 JWT 吊销），但没有任何 UI 入口。

## 改动

- 设置卡片「当前身份」行右侧新增红色 **退出登录** 按钮
- 点击后 POST `/gateway/logout`（服务端立即吊销会话 + 清除 Cookie），随后整页跳转回登录页
- zh/en 双语文案

## 验证

- GET /gateway/logout → 405（保持防跨站登出的安全加固）
- POST /gateway/logout → 302 → /gateway/login（登出成功）
- 113/113 测试通过