### PR TITLE
[codex] fix: keep settings card visible after invalid API responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,11 @@
         "@types/node": "^22.0.0",
         "@types/react": "~18.3.1",
         "@types/react-dom": "~18.3.0",
+        "@types/react-test-renderer": "18.3.1",
         "esbuild": "^0.25.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-test-renderer": "18.3.1",
         "tsx": "^4.19.0",
         "typescript": "^5.5.4"
       },
@@ -1664,6 +1666,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "^18"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/@types/send/-/send-1.2.1.tgz",
@@ -2530,6 +2542,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2628,6 +2650,42 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -84,9 +84,11 @@
     "@types/node": "^22.0.0",
     "@types/react": "~18.3.1",
     "@types/react-dom": "~18.3.0",
+    "@types/react-test-renderer": "18.3.1",
     "esbuild": "^0.25.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-test-renderer": "18.3.1",
     "tsx": "^4.19.0",
     "typescript": "^5.5.4"
   }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,0 +1,35 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function api<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: body === undefined ? undefined : { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  // An expired gateway session redirects fetch to an HTTP 200 HTML login page.
+  if (res.redirected && new URL(res.url).pathname === '/gateway/login') {
+    throw Object.assign(new Error('Please sign in again'), { code: 'NOT_AUTHENTICATED' });
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error(res.ok ? 'Expected a JSON response from the server' : `HTTP ${res.status}`);
+  }
+
+  if (!res.ok) {
+    const details = isRecord(data) ? data : {};
+    throw Object.assign(new Error(typeof details.error === 'string' && details.error
+      ? details.error : `HTTP ${res.status}`), {
+      code: typeof details.code === 'string' ? details.code : undefined,
+    });
+  }
+  if (!isRecord(data)) throw new Error('Expected a JSON object from the server');
+
+  // Callers interpret business results: update/apply can return ok:false while busy.
+  return data as T;
+}

--- a/src/client/card.tsx
+++ b/src/client/card.tsx
@@ -11,6 +11,7 @@
 import { createElement as h, useEffect, useRef, useState } from 'react';
 import type { PropsLocale } from '@deepseek-ai/dsh-client-ui-slots';
 import { publishChatEntryChanged } from './events';
+import { api } from './api';
 
 export interface UserInfo {
   id: number;
@@ -31,6 +32,20 @@ export interface PatchState {
   settingsHostMode: boolean;
   whitelist: boolean;
   workspaceSearch: boolean;
+}
+
+export function readPatchState(response: unknown): PatchState | null {
+  if (typeof response !== 'object' || response === null || !('status' in response)) return null;
+  const status = response.status;
+  if (typeof status !== 'object' || status === null ||
+    !('settingsHostMode' in status) || typeof status.settingsHostMode !== 'boolean' ||
+    !('whitelist' in status) || typeof status.whitelist !== 'boolean' ||
+    !('workspaceSearch' in status) || typeof status.workspaceSearch !== 'boolean') return null;
+  return {
+    settingsHostMode: status.settingsHostMode,
+    whitelist: status.whitelist,
+    workspaceSearch: status.workspaceSearch,
+  };
 }
 
 /** /api/dsh-passwords/update/status 的返回（与网关 UpdateStatus 镜像） */
@@ -146,25 +161,6 @@ function SectionHeader(props: { label: React.ReactNode; status?: React.ReactNode
     h('div', { className: 'dshpw-section-title' }, h('span', { className: 'dshpw-label' }, props.label)),
     props.status === undefined ? null : h(StatusPill, { tone: props.tone, children: props.status }),
   );
-}
-
-type ApiError = { error?: string; code?: string };
-
-function api<T>(path: string, body?: unknown): Promise<T> {
-  return fetch(path, {
-    method: body === undefined ? 'GET' : 'POST',
-    headers: body === undefined ? undefined : { 'content-type': 'application/json' },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  }).then(async (res) => {
-    const data = (await res.json().catch(() => ({}))) as ApiError & T;
-    if (!res.ok) {
-      const err = new Error(data.error || `HTTP ${res.status}`);
-      // 携带服务端稳定错误码：errText 优先按码本地化（跟随 dsh 语言）
-      (err as Error & { code?: string }).code = data.code;
-      throw err;
-    }
-    return data as T;
-  });
 }
 
 /** 错误文案：有 code 走本地词典，未知 code / 无 code 回退服务端文案。
@@ -291,8 +287,8 @@ export function DshPasswordsCard(props: PropsLocale<'dshpw'>) {
         }
       });
     // patch 状态独立于主链（轻量 + 失败只影响状态展示）
-    api<{ status: PatchState | null }>('/api/dsh-passwords/patch/status')
-      .then((r) => setPatchState(r.status))
+    api<unknown>('/api/dsh-passwords/patch/status')
+      .then((r) => setPatchState(readPatchState(r)))
       .catch(() => setPatchState(null));
     // 更新状态独立拉取（失败只降级为状态未知，不阻塞主链）
     api<{ ok?: boolean; status?: UpdateInfo }>('/api/dsh-passwords/update/status')

--- a/test/client-api.test.ts
+++ b/test/client-api.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { api } from '../src/client/api.ts';
+import { readPatchState } from '../src/client/card.tsx';
+
+test('api preserves JSON payloads and GET/POST request options', async (t) => {
+  const fetch = t.mock.method(globalThis, 'fetch', async () => Response.json({ value: 1 }));
+  assert.deepEqual(await api('/test'), { value: 1 });
+  assert.deepEqual(fetch.mock.calls[0].arguments, ['/test', {
+    method: 'GET', headers: undefined, body: undefined,
+  }]);
+  await api('/test', { enabled: false });
+  assert.deepEqual(fetch.mock.calls[1].arguments, ['/test', {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: '{"enabled":false}',
+  }]);
+});
+
+test('api maps a followed login redirect to the existing authentication error code', async (t) => {
+  const response = new Response('<!doctype html><title>Login</title>');
+  Object.defineProperties(response, {
+    redirected: { value: true },
+    url: { value: 'https://example.test/gateway/login?next=%2F' },
+  });
+  t.mock.method(globalThis, 'fetch', async () => response);
+  await assert.rejects(api('/test'), { code: 'NOT_AUTHENTICATED' });
+});
+
+test('api permits non-login redirects returning JSON', async (t) => {
+  const response = Response.json({ value: 1 });
+  Object.defineProperties(response, {
+    redirected: { value: true },
+    url: { value: 'https://example.test/canonical/test' },
+  });
+  t.mock.method(globalThis, 'fetch', async () => response);
+  assert.deepEqual(await api('/test'), { value: 1 });
+});
+
+test('api rejects HTTP 200 HTML instead of silently returning an empty object', async (t) => {
+  t.mock.method(globalThis, 'fetch', async () => new Response('<!doctype html><title>Login</title>'));
+  await assert.rejects(api('/test'), /Expected a JSON response/);
+});
+
+test('api preserves structured HTTP errors for localized messages', async (t) => {
+  t.mock.method(globalThis, 'fetch', async () => Response.json({
+    error: 'Authentication required', code: 'NOT_AUTHENTICATED',
+  }, { status: 401 }));
+  await assert.rejects(api('/test'), {
+    message: 'Authentication required', code: 'NOT_AUTHENTICATED',
+  });
+});
+
+test('api preserves HTTP status for non-JSON proxy errors', async (t) => {
+  t.mock.method(globalThis, 'fetch', async () => new Response('<title>Bad Gateway</title>', { status: 502 }));
+  await assert.rejects(api('/test'), { message: 'HTTP 502' });
+});
+
+for (const payload of [null, [], 'unexpected', 1]) {
+  test(`api rejects non-object JSON: ${JSON.stringify(payload)}`, async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => Response.json(payload));
+    await assert.rejects(api('/test'), /Expected a JSON object/);
+  });
+}
+
+for (const code of ['DOWNLOAD_IN_PROGRESS', 'INSTALL_IN_PROGRESS']) {
+  test(`api leaves HTTP 200 ${code} business results to the caller`, async (t) => {
+    const result = { ok: false, code, message: 'Update already in progress' };
+    t.mock.method(globalThis, 'fetch', async () => Response.json(result));
+    assert.deepEqual(await api('/api/dsh-passwords/update/apply', {}), result);
+  });
+}
+
+test('patch status normalization rejects missing and malformed flags', () => {
+  for (const payload of [
+    undefined, null, [], {}, { status: null }, { status: [] }, { status: {} },
+    { status: { settingsHostMode: true, whitelist: true } },
+    { status: { settingsHostMode: 'true', whitelist: true, workspaceSearch: true } },
+    { status: { settingsHostMode: true, whitelist: 1, workspaceSearch: true } },
+    { status: { settingsHostMode: true, whitelist: true, workspaceSearch: 'false' } },
+  ]) assert.equal(readPatchState(payload), null);
+});
+
+test('patch status normalization preserves valid true and false flags', () => {
+  for (const status of [
+    { settingsHostMode: true, whitelist: true, workspaceSearch: true },
+    { settingsHostMode: false, whitelist: false, workspaceSearch: false },
+    { settingsHostMode: true, whitelist: false, workspaceSearch: true },
+  ]) assert.deepEqual(readPatchState({ status }), status);
+});

--- a/test/client-card.test.ts
+++ b/test/client-card.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { test, type TestContext } from 'node:test';
+import { Component, createElement, type ComponentProps, type ReactNode } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { DshPasswordsCard, type UpdateInfo } from '../src/client/card.tsx';
+
+class CardBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  render() {
+    return this.state.failed ? 'card-crashed' : this.props.children;
+  }
+}
+
+const updateStatus: UpdateInfo = {
+  env: 'npm-prefix', currentVersion: '2.6.4', latestVersion: null,
+  updateAvailable: false, phase: 'idle', downloadPercent: null,
+  downloadMode: null, downloadedBytes: 0, totalBytes: null,
+  pendingVersion: null, installConfirmationRequired: false,
+  lastNotificationAt: null, idleRemainingMs: null, autoUpdateEnabled: false,
+  autoInstallSupported: true, checking: false, manualCommand: '',
+  lastCheckedAt: null, lastError: null, applyCooldownRemainingMs: 0,
+};
+
+function loginResponse() {
+  const response = new Response('<!doctype html><title>Login</title>', {
+    headers: { 'content-type': 'text/html' },
+  });
+  Object.defineProperties(response, {
+    redirected: { value: true },
+    url: { value: 'https://example.test/gateway/login' },
+  });
+  return response;
+}
+
+async function mountCard(t: TestContext, overrides: Record<string, () => Response> = {}) {
+  const intervals = new Map<number, { callback: () => void; delay: number }>();
+  let nextTimer = 0;
+  let renderer: ReactTestRenderer | undefined;
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      setInterval(callback: () => void, delay: number) {
+        intervals.set(++nextTimer, { callback, delay });
+        return nextTimer;
+      },
+      clearInterval(id: number) { intervals.delete(id); },
+      setTimeout,
+    },
+  });
+  t.after(async () => {
+    try {
+      await act(async () => { renderer?.unmount(); });
+    } finally {
+      if (previousWindow) Object.defineProperty(globalThis, 'window', previousWindow);
+      else Reflect.deleteProperty(globalThis, 'window');
+    }
+    assert.equal(intervals.size, 0);
+  });
+  t.mock.method(console, 'error', () => {});
+  const me = { id: 1, username: 'test-admin', role: 'admin' };
+  const payloads: Record<string, unknown> = {
+    '/api/dsh-passwords/state': { me, users: [] },
+    '/gateway/api/overview': { me, users: [], availableWebSocketPaths: [] },
+    '/api/dsh-passwords/workspaces': { workspaces: [] },
+    '/api/dsh-passwords/patch/status': {
+      status: { settingsHostMode: true, whitelist: true, workspaceSearch: true },
+    },
+    '/api/dsh-passwords/update/status': { status: updateStatus },
+  };
+  t.mock.method(globalThis, 'fetch', async (input: string) => {
+    if (overrides[input]) return overrides[input]();
+    assert.ok(input in payloads, `Unexpected request: ${input}`);
+    return Response.json(payloads[input]);
+  });
+  const translate = ((key: string) => key === 'err.NOT_AUTHENTICATED'
+    ? 'Session expired' : key) as ComponentProps<typeof DshPasswordsCard>['t'];
+  await act(async () => {
+    renderer = create(createElement(CardBoundary, {
+      children: createElement(DshPasswordsCard, { t: translate }),
+    }));
+  });
+  return {
+    renderer: renderer!,
+    text: () => JSON.stringify(renderer!.toJSON()),
+    async refresh() {
+      const timer = [...intervals.values()].find(({ delay }) => delay === 30_000);
+      assert.ok(timer, 'Card must retain its refresh timer');
+      await act(async () => { timer.callback(); });
+    },
+  };
+}
+
+test('settings card renders account and patch controls for a healthy response', async (t) => {
+  const card = await mountCard(t);
+  assert.match(card.text(), /test-admin/);
+  assert.match(card.text(), /patchOk/);
+  assert.doesNotMatch(card.text(), /card-crashed/);
+});
+
+test('settings card stays mounted when login expires during refresh', async (t) => {
+  const responses: Record<string, () => Response> = {};
+  const card = await mountCard(t, responses);
+  responses['/api/dsh-passwords/state'] = loginResponse;
+  responses['/api/dsh-passwords/patch/status'] = loginResponse;
+  responses['/api/dsh-passwords/update/status'] = loginResponse;
+  await card.refresh();
+  assert.doesNotMatch(card.text(), /card-crashed/);
+  assert.match(card.text(), /Session expired/);
+  assert.match(card.text(), /patchUnknown/);
+  assert.match(card.text(), /test-admin/);
+});
+
+for (const [label, payload] of [
+  ['missing', {}],
+  ['null', { status: null }],
+  ['malformed', { status: { settingsHostMode: 'true', whitelist: true, workspaceSearch: true } }],
+] as const) {
+  test(`settings card shows unknown for ${label} patch status`, async (t) => {
+    const card = await mountCard(t, {
+      '/api/dsh-passwords/patch/status': () => Response.json(payload),
+    });
+    assert.doesNotMatch(card.text(), /card-crashed/);
+    assert.match(card.text(), /patchUnknown/);
+    assert.match(card.text(), /test-admin/);
+  });
+}
+
+for (const code of ['DOWNLOAD_IN_PROGRESS', 'INSTALL_IN_PROGRESS']) {
+  test(`settings card preserves the ${code} update notice`, async (t) => {
+    const card = await mountCard(t, {
+      '/api/dsh-passwords/update/apply': () => Response.json({
+        ok: false, code, message: 'Update already in progress',
+      }),
+    });
+    const button = card.renderer.root.findByProps({ className: 'dshpw-btn dshpw-update-apply' });
+    assert.equal(button.props.disabled, false);
+    await act(async () => { await button.props.onClick(); });
+    assert.match(card.text(), /Update already in progress/);
+    assert.equal(card.renderer.root.findAllByProps({ className: 'dshpw-error' }).length, 0);
+    assert.doesNotMatch(card.text(), /card-crashed/);
+  });
+}


### PR DESCRIPTION
## Problem

The password-gate settings section can become blank after its gateway session expires. The section heading remains visible, but the account, password and user-management controls disappear.

The gateway redirects unauthenticated requests to `/gateway/login`. Browser `fetch` follows that redirect and receives an HTTP 200 HTML login page. The card's API helper currently swallows JSON parse errors and returns `{}`. The patch-status refresh then stores `undefined` in `patchState`, and the render guard `patchState !== null` permits a read of `undefined.settingsHostMode`. A settings-slot error boundary can consequently remove the whole card. A JSON response missing `status` triggers the same failure.

## Reproduction

1. Sign in through the password gateway and open the password-gate settings section.
2. Expire or revoke that browser session while leaving the section mounted.
3. Allow the next 30-second refresh to follow the login redirect.
4. Observe a blank card and the `settingsHostMode` render exception.

The component regression test reproduces this sequence with synthetic responses and an error boundary, without needing real credentials or a running gateway. It also covers missing and malformed patch status. These three cases failed against the original card before applying the fix.

## Changes

- Extract the card's request helper into a testable client-only module. Reject malformed/non-object JSON instead of silently accepting `{}`.
- Map followed `/gateway/login` redirects to the existing `NOT_AUTHENTICATED` error code so the card displays the existing localized sign-in message. Other redirects returning JSON remain supported.
- Normalize missing/malformed patch status to `null`, retaining the existing unknown-state presentation. Require boolean flags rather than treating truthy strings as successful patch status.
- Preserve structured HTTP error messages/codes and the HTTP status for non-JSON proxy errors.
- Leave HTTP 200 business responses to their callers. In particular, `update/apply` intentionally returns `ok:false` with `DOWNLOAD_IN_PROGRESS` or `INSTALL_IN_PROGRESS`; those results must remain informational notices, not request failures.
- Add 21 API/parser/component regression tests using the existing Node test runner and a React 18 test renderer. Test dependencies are development-only; existing dependency versions are unchanged.

No gateway authorization rules, backend APIs, account data, deployment configuration, or generated bundles are changed. This PR addresses the plugin card, not a separate DSH core bootstrap failure. No real credentials or production logs are included.

## Validation

- Focused regression tests: 21 passed.
- Full suite on Windows with Node 22 and Node 24: 171 tests each, 170 passed, 0 failed, 1 skipped. The existing OpenSSL-dependent SAN test skips because OpenSSL is not installed on this machine.
- `npm ci --ignore-scripts --no-audit --no-fund`: passed with the updated lockfile.
- `npm run build`: passed, including the browser bundle.
- `git diff --check`: passed.

The repository build type-checks the backend and bundles client code with esbuild. An additional standalone client/test type-check was attempted but cannot resolve the upstream host-provided `@deepseek-ai/dsh-client-ui-slots` type import from this checkout; no type-check coverage beyond the existing build is claimed.

The existing GitHub Actions Node 22/24 matrix can provide Linux validation after any required fork-workflow approval.
